### PR TITLE
Docs and docker changes

### DIFF
--- a/development/Dockerfile
+++ b/development/Dockerfile
@@ -35,14 +35,13 @@ RUN apt install locales \
     && update-locale LC_ALL=en_US.UTF-8 LAND=en_US.UTF-8 \
     && export LANG=en_US.UTF-8
 
-
 # Add ROS repo
 RUN apt update \
     && apt upgrade -y \
     && curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -o /usr/share/keyrings/ros-archive-keyring.gpg \
     && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu $(. /etc/os-release && echo $UBUNTU_CODENAME) main" | tee /etc/apt/sources.list.d/ros2.list > /dev/null
 
-# Install (static) gRPC with protobuf, we can use versions newer then the ones used by LUCI because ite regenerated at compile time
+# Install (static) gRPC with protobuf, we can use versions newer then the ones used by LUCI because its regenerated at compile time
 RUN git clone -b v1.56.2 https://github.com/grpc/grpc grpc \
     && cd grpc \
     && git submodule update --init \
@@ -67,7 +66,6 @@ RUN apt update \
     debhelper \
     dh-python \
     && apt-get clean
-
 
 # Install Foxglove support
 RUN apt install ros-humble-foxglove-bridge -y

--- a/docs/2_Installation/4_luci-ros2-sdk-install.md
+++ b/docs/2_Installation/4_luci-ros2-sdk-install.md
@@ -22,27 +22,25 @@ Each package is published to an apt repository upon release and is added by firs
 
 If this is your first time using the LUCI ROS2 SDK repository you need to first add the repo and gpg key to you system. This informs your computer that the LUCI .deb packages exist and can be installed.
 
-Note you will only need to run the next two commands the first time you need to install our packages on your system. If you are updating existing LUCI packages this is not needed
-
 ### Add the GPG key
 
-`curl -fsSL https://luci.jfrog.io/artifactory/api/security/keypair/humble-sdk-key/public | gpg --dearmor -o /usr/share/keyrings/ros2-sdk-packages.gpg`
+`curl -fsSL https://luci.jfrog.io/artifactory/api/security/keypair/ros-humble-keys/public | sudo gpg --dearmor -o /usr/share/keyrings/ros2-sdk-packages.gpg`
 
 ### Add the debian repository to sources file
 
-`sudo sh -c "echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/ros2-sdk-packages.gpg] https://luci.jfrog.io/artifactory/ros2-sdk-packages jammy private' >> /etc/apt/sources.list"`
+`echo "deb [signed-by=/usr/share/keyrings/ros2-sdk-packages.gpg] https://luci.jfrog.io/artifactory/ros2-sdk-packages jammy private" | sudo tee /etc/apt/sources.list.d/ros2-sdk-packages.list > /dev/null`
 
 ### Install the package
 
-Once you have added the repo and gpg key for the LUCI ROS2 packages you can install all by running the command below
+Once you have added the repo and gpg key for the LUCI ROS2 packages you can install all by running the command below. These will install the latest updated versions of the package. 
 
 ```
 sudo apt update
-apt install ros-humble-luci-basic-teleop=1.0.0-0jammy 
-apt install ros-humble-luci-grpc-interface=1.0.0-0jammy 
-apt install ros-humble-luci-messages=1.0.0-0jammy 
-apt install ros-humble-luci-third-party=1.1.0-0jammy 
-apt install ros-humble-luci-transforms=1.0.0-0jammy
+apt install ros-humble-luci-basic-teleop
+apt install ros-humble-luci-grpc-interface
+apt install ros-humble-luci-messages
+apt install ros-humble-luci-third-party
+apt install ros-humble-luci-transforms
 ```
 
 After each install you should see it downloaded the version of the package that matches the version number listed in the versions.json file
@@ -53,22 +51,22 @@ To check the version of a given package run
 
 For examble to check the basic-teleop package you would run
 
-`apt show ros-humble-luci-basic-teleop`
+`apt show ros-humble-luci-messages`
 
 and the output should be similar to this
 
 ```
-Package: ros-humble-luci-basic-teleop
-Version: 1.0.0-0focal
+Package: ros-humble-luci-messages
+Version: 2.0.0-0jammy
 Priority: optional
 Section: misc
-Installed-Size: 45.1 kB
-Depends: ros-galactic-rclpy, ros-galactic-std-msgs
-Download-Size: 8,100 B
+Maintainer: shail <shail@luci.com>
+Installed-Size: 1185 kB
+Depends: libc6 (>= 2.4), libgcc-s1 (>= 3.3.1), libpython3.10 (>= 3.10.0), libstdc++6 (>= 5.2), ros-humble-fastcdr, ros-humble-rosidl-default-runtime, ros-humble-std-msgs
+Download-Size: 84.7 kB
 APT-Manual-Installed: yes
 APT-Sources: https://luci.jfrog.io/artifactory/ros2-sdk-packages jammy/private amd64 Packages
-Description: An example node that can be used to drive LUCI using the arrow keys on your keyboard.
- ctrl+c or q to terminate. Compatible with Linux.
+Description: Custom Luci message types
 
 ```
 

--- a/release/Dockerfile
+++ b/release/Dockerfile
@@ -42,16 +42,17 @@ RUN apt update \
 RUN apt update \
     && apt install -y ros-dev-tools \
     && apt install -y ros-humble-desktop
+
 # Install LUCI ROS2 SDK
 RUN cd \
-    && curl -fsSL https://luci.jfrog.io/artifactory/api/security/keypair/humble-sdk-key/public | gpg --dearmor -o /usr/share/keyrings/ros2-sdk-packages.gpg \
+    && curl -fsSL https://luci.jfrog.io/artifactory/api/security/keypair/ros-humble-keys/public | sudo gpg --dearmor -o /usr/share/keyrings/ros2-sdk-packages.gpg\
     && sh -c "echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/ros2-sdk-packages.gpg] https://luci.jfrog.io/artifactory/ros2-sdk-packages jammy private' >> /etc/apt/sources.list"\
     && apt update \
-    && apt install ros-humble-luci-basic-teleop=1.0.0-0jammy \
-    && apt install ros-humble-luci-grpc-interface=1.3.0-0jammy \
-    && apt install ros-humble-luci-messages=1.3.0-0jammy \
-    && apt install ros-humble-luci-third-party=1.2.0-0jammy \
-    && apt install ros-humble-luci-transforms=1.0.0-0jammy
+    && apt install ros-humble-luci-basic-teleop \
+    && apt install ros-humble-luci-grpc-interface \
+    && apt install ros-humble-luci-messages \
+    && apt install ros-humble-luci-third-party \
+    && apt install ros-humble-luci-transforms
 
 # Hold all LUCI packages so they dont auto update on apt update
 RUN apt-mark hold ros-humble-luci-basic-teleop \
@@ -59,7 +60,6 @@ RUN apt-mark hold ros-humble-luci-basic-teleop \
     && apt-mark hold ros-humble-luci-messages \
     && apt-mark hold ros-humble-luci-third-party \
     && apt-mark hold ros-humble-luci-transforms
-
 
 # Install Foxglove support
 RUN apt install ros-humble-foxglove-bridge -y


### PR DESCRIPTION
- Release docker now has debians without a release tag to get the latest version right keyrings
- Install docs now have debians install without release tag for latest version and right keyrings
- Changed `apt show` example in download docs
- Basic cleanup